### PR TITLE
Add Sample to pprof conversion

### DIFF
--- a/internal/deep_copy_parser.go
+++ b/internal/deep_copy_parser.go
@@ -23,29 +23,7 @@ import (
 	"strings"
 )
 
-// Frame represnets a frame in the stack.
-type Frame struct {
-	Parent       *Frame
-	Children     []*Frame
-	SelfWeightNs int64
-	SymbolName   string
-	Depth        int
-}
 
-func (f *Frame) String() string {
-	return fmt.Sprintf("{SymbolName: %s Weight:%d n_children:%d, Depth:%d}", f.SymbolName, f.SelfWeightNs, len(f.Children), f.Depth)
-}
-
-// Thread represents the second level of the stack.
-type Thread struct {
-	Name   string
-	Tid    uint64
-	Frames []*Frame
-}
-
-func (t *Thread) String() string {
-	return fmt.Sprintf("thread {name: %s tid: %d n_frames: %d}", t.Name, t.Tid, len(t.Frames))
-}
 
 func newThreadFromFrame(f *Frame) (*Thread, error) {
 	if f.Depth != 1 {
@@ -74,17 +52,6 @@ func newThreadFromFrame(f *Frame) (*Thread, error) {
 	}, nil
 }
 
-// Process are the top level of the stack.
-type Process struct {
-	Name    string
-	Pid     uint64
-	Threads []*Thread
-}
-
-func (p *Process) String() string {
-	return fmt.Sprintf("process {name: %s pid: %d n_processes: %d}", p.Name, p.Pid, len(p.Threads))
-}
-
 func newProcessFromFrame(f *Frame) (*Process, error) {
 	if f.Depth != 0 {
 		return nil, fmt.Errorf("Process must have depth 1, was %d: %v", f.Depth, f)
@@ -110,11 +77,6 @@ func newProcessFromFrame(f *Frame) (*Process, error) {
 		Pid:     pid,
 		Threads: make([]*Thread, 0),
 	}, nil
-}
-
-// TimeProfile is a set of processes parsed from the deep copy.
-type TimeProfile struct {
-	Processes []*Process
 }
 
 func parseSelfWeight(selfWeightText string) (int64, error) {
@@ -173,9 +135,6 @@ func parseLine(line string) (*Frame, error) {
 func ParseDeepCopy(file io.Reader) (p *TimeProfile, err error) {
 	p = &TimeProfile{}
 
-	// Parse process TODO: Multiprocess
-	// Todo: Process name is "process_name (<pid>)"
-	// Todo: Thread id is "thread_name 0x<tid>"
 	buf := bufio.NewReader(file)
 	// First line must match header
 	// Now parse away since first line was good.

--- a/internal/sample_parser.go
+++ b/internal/sample_parser.go
@@ -1,0 +1,223 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ParseDeepCopy parses the deep copy from the input.
+package internal
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	functionRe = regexp.MustCompile(`([+\s!:|]*)(\d+)\s+(.*)$`)
+)
+
+func parseCallLine(line string) (f *Frame, err error) {
+	matches := functionRe.FindStringSubmatch(line)
+	if matches == nil || len(matches) != 4 {
+		return nil, fmt.Errorf("Failed to parse function line: %s", line)
+	}
+	hits, err := strconv.ParseInt(matches[2], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing function line %s: %v", line, err)
+	}
+
+	return &Frame{
+		SymbolName:   matches[3],
+		SelfWeightNs: hits,
+		// 2 spaces per depth.
+		Depth: len(matches[1]) / 2,
+	}, nil
+}
+
+func fixSelfWeight(frame *Frame) error {
+	for _, child := range frame.Children {
+		frame.SelfWeightNs -= child.SelfWeightNs
+		if frame.SelfWeightNs < 0 {
+			return fmt.Errorf(
+				"Fatal error parsing sample file. Frame %s had negative weight. The file is either corrupt or this is a bug.",
+				frame.SymbolName)
+		}
+		fixSelfWeight(child)
+	}
+	return nil
+}
+
+var (
+	pidRe = regexp.MustCompile(`(.*)\s\[(\d+)\]`)
+)
+
+func parseProcess(line string) (p *Process, err error) {
+	// Parse process line, which looks like,
+	// Process:         Google Chrome Helper (Renderer) [56690]
+	invalid_line := fmt.Errorf("Not valid process line %s", line)
+	if !strings.HasPrefix(line, "Process") {
+		return nil, invalid_line
+	}
+	parts := strings.Split(line, ":")
+	if len(parts) != 2 {
+		return nil, invalid_line
+	}
+	pid_part := strings.TrimSpace(parts[1])
+	matches := pidRe.FindStringSubmatch(pid_part)
+	if matches == nil || len(matches) != 3 {
+		return nil, fmt.Errorf("Error parsing process and pid from %s: %v", pid_part, matches)
+	}
+	pid, err := strconv.ParseUint(matches[2], 10, 64)
+	return &Process{
+		Pid: pid,
+		Name: matches[1],
+	}, nil
+}
+
+func parseSampleRate(line string) int64 {
+	parts := strings.Split(line, " ")
+	n := len(parts)
+	unit := parts[n-1]
+	period := parts[n-2]
+	// TODO(eshrubs): Implement frequency parsing.
+	if (period != "1" && unit != "millisecond") {
+		log.Printf(
+			"WARNING: Period parsing is not yet supported. Defaulting to 1ms period but period of %s %s was detected",
+		 	period, unit)
+	}
+	return 1_000_000
+}
+
+func ParseSample(file io.Reader) (p *TimeProfile, err error) {
+	p = &TimeProfile{}
+
+	buf := bufio.NewReader(file)
+
+	// Default sample rate of 1ms == 1,000,000 ns
+	var sampleRate int64 = 1_000_000
+	// TODO(eshr): Parse sample rate
+	// Parse header
+	for {
+		line, err := buf.ReadString('\n')
+		if line == "" && err != nil {
+			// Break once end of file.
+			if err == io.EOF {
+				return nil, errors.New("Could not create trace, could not find the 'Call Graph' line.")
+			}
+			return nil, err
+		}
+
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Analysis of sampling") {
+			sampleRate = parseSampleRate(line)
+		}
+		if strings.HasPrefix(line, "Report Version") {
+			parts := strings.Split(line, ":")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("Could not parse report version line: %s", line)
+			}
+			reportVersion, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing report version: %v", err)
+			}
+			if reportVersion != 7 {
+				return nil, fmt.Errorf("Report Version was %d, only report version 7 is supported", reportVersion)
+			}
+		}
+		if strings.HasPrefix(line, "Process") {
+			if len(p.Processes) > 0 {
+				return nil, errors.New("More than one process line present. Currupt sample file")
+			}
+			process, err := parseProcess(line)
+			if err != nil {
+				return nil, err
+			}
+			p.Processes = append(p.Processes, process)
+		}
+		if strings.HasPrefix(line, "Call graph") {
+			break
+		}
+	}
+	process := p.Processes[0]
+	var currentThread *Thread = nil
+	var lastFrame *Frame = nil
+	for {
+		line, err := buf.ReadString('\n')
+		if line == "" && err != nil {
+			// Break once end of file.
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+
+		// Call stack is over
+		if line == "" {
+			break
+		}
+
+		// Parse a function.
+		currentFrame, err := parseCallLine(line)
+		if err != nil {
+			return nil, err
+		}
+		if currentFrame.Depth == 0 {
+			// New thread!
+			currentThread = &Thread{
+				Name: currentFrame.SymbolName,
+			}
+			process.Threads = append(process.Threads, currentThread)
+		} else if currentFrame.Depth == 1 {
+			// First frame in thread
+			currentThread.Frames = append(currentThread.Frames, currentFrame)
+		} else if currentFrame.Depth > lastFrame.Depth {
+			// Child frame
+			if currentFrame.Depth-lastFrame.Depth != 1 {
+				return nil, fmt.Errorf("Skipped frame depth from frame %s to %s",
+					lastFrame.SymbolName, currentFrame.SymbolName)
+			}
+			lastFrame.Children = append(lastFrame.Children, currentFrame)
+			currentFrame.Parent = lastFrame
+		} else {
+			// Find parent
+			var parent *Frame = lastFrame.Parent
+			for {
+				if parent.Depth == currentFrame.Depth-1 {
+					parent.Children = append(parent.Children, currentFrame)
+					currentFrame.Parent = parent
+					break
+				}
+				parent = parent.Parent
+			}
+		}
+		currentFrame.SelfWeightNs *= sampleRate
+		lastFrame = currentFrame
+	}
+
+	// Fix weights
+	for _, thread := range process.Threads {
+		for _, frame := range thread.Frames {
+			err := fixSelfWeight(frame)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return p, nil
+}

--- a/internal/sample_parser_test.go
+++ b/internal/sample_parser_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	validDeepCopy = `Analysis of sampling Process Name (pid 56690) every 1 millisecond
+Process:         ProcessName [56690]
+Path:            /Applications/Process.app/Contents/Frameworks/
+Load Address:    0x10b6ed000
+Identifier:      ProcessName
+Version:         ???
+Code Type:       X86-64
+Platform:        macOS
+
+Date/Time:       2021-03-15 15:41:58.406 +0100
+Launch Time:     2021-03-15 15:30:30.917 +0100
+OS Version:      macOS 11.2.2 (20D80)
+Report Version:  7
+Analysis Tool:   /usr/bin/sample
+
+Physical footprint:         530.5M
+Physical footprint (peak):  538.4M
+----
+
+Call graph:
+    4 Thread1 DispatchQueue1: com.apple.main-thread  (serial)
+    + 4 start
+    +   4 eatLunch
+    +   : 3 makeSandwhich
+    +   : ! 1 getBread(BreadType)
+    +   : !	1 getCheese(CheeseType)
+    +   : 1 eatFood(Food const&)
+    1 Thread2 DispatchQueue1: com.apple.main-thread  (serial)
+    + 1 listenToMusic()
+		`
+)
+
+func TestSampleParsing(t *testing.T) {
+	r := strings.NewReader(validDeepCopy)
+	timeProfile, err := ParseSample(r)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	expected := &TimeProfile{
+		Processes: []*Process{
+			{
+				Name: "ProcessName",
+				Pid:  56690,
+				Threads: []*Thread{
+					{
+						Name: "Thread1 DispatchQueue1: com.apple.main-thread  (serial)",
+						Tid:  0,
+						Frames: []*Frame{
+							{
+								SymbolName:   "start",
+								Depth:        1,
+								SelfWeightNs: 0,
+								Children: []*Frame{
+									{
+										SymbolName:   "eatLunch",
+										Depth:        2,
+										SelfWeightNs: 0,
+										Children: []*Frame{
+											{
+												SymbolName:   "makeSandwhich",
+												Depth:        3,
+												SelfWeightNs: 1_000_000,
+												Children: []*Frame{
+													{
+														SymbolName:   "getBread(BreadType)",
+														Depth:        4,
+														SelfWeightNs: 1_000_000,
+														Children:     []*Frame{},
+													}, {
+														SymbolName:   "getCheese(CheeseType)",
+														Depth:        4,
+														SelfWeightNs: 1_000_000,
+														Children:     []*Frame{},
+													},
+												},
+											},
+											{
+												SymbolName:   "eatFood(Food const&)",
+												Depth:        3,
+												SelfWeightNs: 1_000_000,
+												Children:     []*Frame{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "Thread2 DispatchQueue1: com.apple.main-thread  (serial)",
+						Tid:  0,
+						Frames: []*Frame{
+							{
+								SymbolName:   "listenToMusic()",
+								Depth:        1,
+								SelfWeightNs: 1_000_000,
+								Children:     []*Frame{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	timeProfileEquals(t, timeProfile, expected)
+}

--- a/internal/time_profile_to_pprof.go
+++ b/internal/time_profile_to_pprof.go
@@ -253,8 +253,8 @@ func (toPprof *deepCopyToPprofConverter) convertToPprof() *profile.Profile {
 	}
 }
 
-// ConvertDeepCopyToProfile converts a TimeProfile to a pprof Profile.
-func ConvertDeepCopyToProfile(deepCopy *TimeProfile,
+// TimeProfileToPprof converts a TimeProfile to a pprof Profile.
+func TimeProfileToPprof(deepCopy *TimeProfile,
 	excludeProcessesFromStack bool,
 	excludeThreadsFromStack bool,
 	includeThreadAndProcessIds bool,

--- a/internal/time_profile_to_pprof_test.go
+++ b/internal/time_profile_to_pprof_test.go
@@ -49,7 +49,7 @@ func MakeDeepCopy() *TimeProfile {
 var NoAnnotations ProcessAnnotationMap = make(map[uint64](string))
 
 func TestIncludeProcessAndThreads(t *testing.T) {
-	got := ConvertDeepCopyToProfile(MakeDeepCopy(), false, false, true, NoAnnotations)
+	got := TimeProfileToPprof(MakeDeepCopy(), false, false, true, NoAnnotations)
 	if len(got.Sample) != 1 {
 		t.Errorf("Expected only 1 sample, got %v", got)
 	}
@@ -69,7 +69,7 @@ func TestIncludeProcessAndThreads(t *testing.T) {
 }
 
 func TestIncludeProcessAndThreadsNoIds(t *testing.T) {
-	got := ConvertDeepCopyToProfile(MakeDeepCopy(), false, false, false, NoAnnotations)
+	got := TimeProfileToPprof(MakeDeepCopy(), false, false, false, NoAnnotations)
 	if len(got.Sample) != 1 {
 		t.Errorf("Expected only 1 sample, got %v", got)
 	}
@@ -89,7 +89,7 @@ func TestIncludeProcessAndThreadsNoIds(t *testing.T) {
 }
 
 func TestExcludeThreads(t *testing.T) {
-	got := ConvertDeepCopyToProfile(MakeDeepCopy(), false, true, true, NoAnnotations)
+	got := TimeProfileToPprof(MakeDeepCopy(), false, true, true, NoAnnotations)
 	if len(got.Sample) != 1 {
 		t.Errorf("Expected only 1 sample, got %v", got)
 	}
@@ -105,7 +105,7 @@ func TestExcludeThreads(t *testing.T) {
 }
 
 func TestExcludeProcesses(t *testing.T) {
-	got := ConvertDeepCopyToProfile(MakeDeepCopy(), true, false, true, NoAnnotations)
+	got := TimeProfileToPprof(MakeDeepCopy(), true, false, true, NoAnnotations)
 	if len(got.Sample) != 1 {
 		t.Errorf("Expected only 1 sample, got %v", got)
 	}
@@ -121,7 +121,7 @@ func TestExcludeProcesses(t *testing.T) {
 }
 
 func TestExcludeProcessesAndThreads(t *testing.T) {
-	got := ConvertDeepCopyToProfile(MakeDeepCopy(), true, true, true, NoAnnotations)
+	got := TimeProfileToPprof(MakeDeepCopy(), true, true, true, NoAnnotations)
 	if len(got.Sample) != 1 {
 		t.Errorf("Expected only 1 sample, got %v", got)
 	}
@@ -140,7 +140,7 @@ func TestProcessAnnotations(t *testing.T) {
 	annotations := make(map[uint64](string))
 	annotations[123] = "MyAnnotation"
 	annotations[1337] = "ExtraAnnotation"
-	got := ConvertDeepCopyToProfile(MakeDeepCopy(), false, true, true, annotations)
+	got := TimeProfileToPprof(MakeDeepCopy(), false, true, true, annotations)
 	if len(got.Sample) != 1 {
 		t.Errorf("Expected only 1 sample, got %v", got)
 	}

--- a/internal/trace_types.go
+++ b/internal/trace_types.go
@@ -1,0 +1,71 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Frame represnets a frame in the stack.
+type Frame struct {
+	Parent       *Frame
+	Children     []*Frame
+	SelfWeightNs int64
+	SymbolName   string
+	Depth        int
+}
+
+func (f *Frame) String() string {
+	space := strings.Repeat("  ", f.Depth)
+	children_str := "{"
+	for _, child := range f.Children {
+		children_str += fmt.Sprintf("\n%s%s,", space, child)
+	}
+	children_str += "\n}"
+	var parent_name = "nil"
+	if f.Parent != nil {
+		parent_name = f.Parent.SymbolName
+	}
+	return fmt.Sprintf("{SymbolName: %s Parent: %s Weight:%d Depth:%d Children:%s}",
+		f.SymbolName, parent_name, f.SelfWeightNs, f.Depth, children_str)
+}
+
+// Thread represents the second level of the stack.
+type Thread struct {
+	Name   string
+	Tid    uint64
+	Frames []*Frame
+}
+
+func (t *Thread) String() string {
+	return fmt.Sprintf("thread {name: %s tid: %d frames:\n%v\n]}", t.Name, t.Tid, t.Frames)
+}
+
+// Process are the top level of the stack.
+type Process struct {
+	Name    string
+	Pid     uint64
+	Threads []*Thread
+}
+
+func (p *Process) String() string {
+	return fmt.Sprintf("process {name: %s pid: %d n_processes: %d}", p.Name, p.Pid, len(p.Threads))
+}
+
+// TimeProfile is a set of processes parsed from the deep copy.
+type TimeProfile struct {
+	Processes []*Process
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ParseDeepCopy parses the deep copy from the input.
+package internal
+
+import (
+	"testing"
+)
+
+func frameEquals(t *testing.T, a *Frame, b *Frame) {
+	t.Helper()
+	if (a == nil && b == nil) {
+		return;
+	}
+	if (a == nil || b == nil) {
+		t.Fatalf("One frame was nil %v != %v", a, b)
+	}
+	if (a.SymbolName != b.SymbolName) {
+		t.Errorf("SymbolName %s != %s", a.SymbolName, b.SymbolName)
+	}
+	if (a.Depth != b.Depth) {
+		t.Errorf("%s frame depth %d != %d", a.SymbolName, a.Depth, b.Depth)
+	}
+	if (a.SelfWeightNs != b.SelfWeightNs) {
+		t.Errorf("%s self weight %d != %d", a.SymbolName, a.SelfWeightNs, b.SelfWeightNs)
+	}
+	if (len(a.Children) != len(b.Children)) {
+		t.Fatalf("%s have different children lengths %v != %v", a.SymbolName, a.Children, b.Children)
+	}
+	for i, aChild := range a.Children {
+		bChild := b.Children[i]
+		frameEquals(t, aChild, bChild)
+	}
+}
+
+func threadEquals(t *testing.T, a *Thread, b *Thread) {
+	t.Helper()
+	if (a.Name != b.Name) {
+		t.Errorf("Threads have different names %s != %s", a.Name, b.Name)
+	}
+	if (a.Tid != b.Tid) {
+		t.Errorf("Thread %s have different tids %d != %d", a.Name, a.Tid, b.Tid)
+	}
+	if len(a.Frames) != len(b.Frames) {
+		t.Fatalf("Thread %s have different number of frames %v != %v", a.Name, a.Frames, b.Frames)
+	}
+	for i, aChild := range a.Frames {
+		bChild := b.Frames[i]
+		frameEquals(t, aChild, bChild)
+	}
+}
+
+func processEquals(t *testing.T, a *Process, b *Process) {
+	t.Helper()
+	if (a.Name != b.Name) {
+		t.Errorf("Processes have diferent Names %s != %s", a.Name, b.Name)
+	}
+	if (a.Pid != b.Pid) {
+		t.Errorf("Process has different pids %d != %d", a.Pid, b.Pid)
+	}
+	if len(a.Threads) != len(b.Threads) {
+		t.Fatalf("Processes have different number of threads %d != %d",
+		len(a.Threads), len(b.Threads))
+	}
+	for i, aThread := range a.Threads {
+		bThread := b.Threads[i]
+		threadEquals(t, aThread, bThread)
+	}
+}
+
+func timeProfileEquals(t *testing.T, a *TimeProfile, b *TimeProfile) {
+	t.Helper()
+	if (len(a.Processes) != len(b.Processes)) {
+		t.Fatalf("Time profiles had different number of processes %d != %d",
+		len(a.Processes), len(b.Processes))
+	}
+	for i, aProcess := range a.Processes {
+		bProcess := b.Processes[i]
+		processEquals(t, aProcess, bProcess)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -55,7 +55,6 @@ func main() {
 	if inputFile == "-" || inputFile == "" {
 		input = os.Stdin
 	} else {
-		var err error
 		file, err := os.Open(inputFile)
 		if err != nil {
 			log.Fatalf("Failed to open %s: %v", inputFile, err)
@@ -67,7 +66,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to parse deep copy: %v", err)
 	}
-	pprof := internal.ConvertDeepCopyToProfile(timeProfile, *excludeProcessInStack, *excludeThreadsInStack, !*excludeIds, processAnnotations)
+	pprof := internal.TimeProfileToPprof(timeProfile, *excludeProcessInStack, *excludeThreadsInStack, !*excludeIds, processAnnotations)
 	if err = pprof.CheckValid(); err != nil {
 		log.Fatalf("Invalid profile: %v\n", err)
 	}


### PR DESCRIPTION
Adds sample parser which will be wired up to main.go after some refactoring to support multiple parsers.

Changes made
- Move the parse types to trace_types.go
- Add testing utilities for the trace_types. This should be used eventually in other tests.