### PR TITLE
Add support for collapsed stack file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 
 build/
 .vscode/
+
+*.swp
+
+instrumentsToPprof

--- a/internal/parsers/collapsed/collapsed_parser.go
+++ b/internal/parsers/collapsed/collapsed_parser.go
@@ -15,7 +15,7 @@
 package collapsed
 
 import (
-	"bufio"
+  "bufio"
   "io"
   "strconv"
   "strings"
@@ -24,34 +24,34 @@ import (
 )
 
 func MakeCollapsedParser(file io.Reader) (d CollapsedParser, err error) {
-	d = CollapsedParser{
-		lines: []string{},
-	}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		d.lines = append(d.lines, scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		return d, err
-	}
-	return d, nil
+  d = CollapsedParser{
+    lines: []string{},
+  }
+  scanner := bufio.NewScanner(file)
+  for scanner.Scan() {
+    d.lines = append(d.lines, scanner.Text())
+  }
+  if err := scanner.Err(); err != nil {
+    return d, err
+  }
+  return d, nil
 }
 
 // This parser supports the "collapsed stack" file format where each line of 
 // the file represents a full stack sample. This is a format commonly used
 // to generate flamegraphs.
 type CollapsedParser struct {
-	lines []string
+  lines []string
 }
 
 func (d CollapsedParser) ParseProfile() (p *internal.TimeProfile, err error) {
-	p = &internal.TimeProfile{}
-  
+  p = &internal.TimeProfile{}
+
   // Collapsed format merges all processes so just create a dummy one.
   var process = &internal.Process{
-		Pid:  0,
-		Name: "",
-	}
+    Pid:  0,
+    Name: "",
+  }
   p.Processes = append(p.Processes, process)
 
   // Collapsed format merges all threads so just create a dummy one.
@@ -61,14 +61,14 @@ func (d CollapsedParser) ParseProfile() (p *internal.TimeProfile, err error) {
 
   process.Threads = append(process.Threads, currentThread)
 
-	for _, line := range d.lines {
-		currentFrame, err := parseCallLine(line)
+  for _, line := range d.lines {
+    currentFrame, err := parseCallLine(line)
     if err == nil {
       currentThread.Frames = append(currentThread.Frames, currentFrame)
     }
   }
 
-	return p, nil
+  return p, nil
 }
 
 func parseCallLine(line string) (f *internal.Frame, err error) {
@@ -84,15 +84,15 @@ func parseCallLine(line string) (f *internal.Frame, err error) {
 
   // Collapsed stack format is explicit about weights so assign a weight of
   // zero to everything expect the leaf function.
-	var frame = &internal.Frame{
-		SymbolName:  funs[0],
-		SelfWeightNs: 0,
-		Depth: 0,
-	}
+  var frame = &internal.Frame{
+    SymbolName:  funs[0],
+    SelfWeightNs: 0,
+    Depth: 0,
+  }
 
   // Build the stack by going over every function.
   var last_frame *internal.Frame = frame;
-	for index, fun := range funs{
+  for index, fun := range funs{
     if index == 0 {
       continue
     }

--- a/internal/parsers/collapsed/collapsed_parser.go
+++ b/internal/parsers/collapsed/collapsed_parser.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package collapsed
 
 import (
 	"bufio"
-  //"fmt"
   "io"
   "strconv"
   "strings"
@@ -38,12 +37,14 @@ func MakeCollapsedParser(file io.Reader) (d CollapsedParser, err error) {
 	return d, nil
 }
 
+// This parser supports the "collapsed stack" file format where each line of 
+// the file represents a full stack sample. This is a format commonly used
+// to generate flamegraphs.
 type CollapsedParser struct {
 	lines []string
 }
 
 func (d CollapsedParser) ParseProfile() (p *internal.TimeProfile, err error) {
-	// TODO: Implement parsing in the struct.
 	p = &internal.TimeProfile{}
   
   // Collapsed format merges all processes so just create a dummy one.
@@ -72,17 +73,24 @@ func (d CollapsedParser) ParseProfile() (p *internal.TimeProfile, err error) {
 
 func parseCallLine(line string) (f *internal.Frame, err error) {
 
+  // Find the separating space in the line.
   sep := strings.LastIndex(line, " ") 
 
+  // The frequence is everything after the space.
   frequence, err := strconv.ParseInt(line[sep+1:len(line)], 10, 64)
+
+  // The semi-colon separated functions are everything before the semi-colon.
   funs := strings.Split(line[0:sep], ";")
 
+  // Collapsed stack format is explicit about weights so assign a weight of
+  // zero to everything expect the leaf function.
 	var frame = &internal.Frame{
 		SymbolName:  funs[0],
 		SelfWeightNs: 0,
 		Depth: 0,
 	}
 
+  // Build the stack by going over every function.
   var last_frame *internal.Frame = frame;
 	for index, fun := range funs{
     if index == 0 {
@@ -100,6 +108,7 @@ func parseCallLine(line string) (f *internal.Frame, err error) {
     last_frame = current_frame
   }
 
+  // Assign the weight to the leaf function.
   last_frame.SelfWeightNs = frequence
 
   return frame, nil

--- a/internal/parsers/collapsed/collapsed_parser.go
+++ b/internal/parsers/collapsed/collapsed_parser.go
@@ -16,6 +16,7 @@ package collapsed
 
 import (
   "bufio"
+  "fmt"
   "io"
   "strconv"
   "strings"
@@ -80,9 +81,15 @@ func parseCallLine(line string) (f *internal.Frame, err error) {
 
   // The frequence is everything after the space.
   frequence, err := strconv.ParseInt(line[sep+1:len(line)], 10, 64)
+  if err != nil{
+    return nil, nil
+  }
 
   // The semi-colon separated functions are everything before the semi-colon.
   funs := strings.Split(line[0:sep], ";")
+  if len(funs) == 0 {
+    return nil, fmt.Errorf("Error parsing function names.")
+  }
 
   // Collapsed stack format is explicit about weights so assign a weight of
   // zero to everything expect the leaf function.

--- a/internal/parsers/collapsed/collapsed_parser.go
+++ b/internal/parsers/collapsed/collapsed_parser.go
@@ -1,0 +1,106 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collapsed
+
+import (
+	"bufio"
+  //"fmt"
+  "io"
+  "strconv"
+  "strings"
+
+  "github.com/google/instrumentsToPprof/internal"
+)
+
+func MakeCollapsedParser(file io.Reader) (d CollapsedParser, err error) {
+	d = CollapsedParser{
+		lines: []string{},
+	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		d.lines = append(d.lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return d, err
+	}
+	return d, nil
+}
+
+type CollapsedParser struct {
+	lines []string
+}
+
+func (d CollapsedParser) ParseProfile() (p *internal.TimeProfile, err error) {
+	// TODO: Implement parsing in the struct.
+	p = &internal.TimeProfile{}
+  
+  // Collapsed format merges all processes so just create a dummy one.
+  var process = &internal.Process{
+		Pid:  0,
+		Name: "",
+	}
+  p.Processes = append(p.Processes, process)
+
+  // Collapsed format merges all threads so just create a dummy one.
+  var currentThread = &internal.Thread{
+    Name: "",
+  }
+
+  process.Threads = append(process.Threads, currentThread)
+
+	for _, line := range d.lines {
+		currentFrame, err := parseCallLine(line)
+    if err == nil {
+      currentThread.Frames = append(currentThread.Frames, currentFrame)
+    }
+  }
+
+	return p, nil
+}
+
+func parseCallLine(line string) (f *internal.Frame, err error) {
+
+  sep := strings.LastIndex(line, " ") 
+
+  frequence, err := strconv.ParseInt(line[sep+1:len(line)], 10, 64)
+  funs := strings.Split(line[0:sep], ";")
+
+	var frame = &internal.Frame{
+		SymbolName:  funs[0],
+		SelfWeightNs: 0,
+		Depth: 0,
+	}
+
+  var last_frame *internal.Frame = frame;
+	for index, fun := range funs{
+    if index == 0 {
+      continue
+    }
+
+    var current_frame = &internal.Frame{
+      SymbolName:  fun,
+      SelfWeightNs: 0,
+      Depth: index,
+    }
+
+    current_frame.Parent = last_frame
+    last_frame.Children = append(last_frame.Children, current_frame)
+    last_frame = current_frame
+  }
+
+  last_frame.SelfWeightNs = frequence
+
+  return frame, nil
+}

--- a/internal/parsers/collapsed/collapsed_parser.go
+++ b/internal/parsers/collapsed/collapsed_parser.go
@@ -65,6 +65,8 @@ func (d CollapsedParser) ParseProfile() (p *internal.TimeProfile, err error) {
     currentFrame, err := parseCallLine(line)
     if err == nil {
       currentThread.Frames = append(currentThread.Frames, currentFrame)
+    } else{
+      return p, err
     }
   }
 

--- a/internal/parsers/collapsed/collapsed_parser_test.go
+++ b/internal/parsers/collapsed/collapsed_parser_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collapsed
+
+import (
+  "strings"
+	"testing"
+)
+
+func TestLineParsing(t *testing.T) {
+  const collapsed = "Bar;Baz 2\n" +
+  "Foo 2\n"
+
+	r := strings.NewReader(collapsed)
+	parser, err := MakeCollapsedParser(r)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	parsed_profile, err := parser.ParseProfile()
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+  if(len(parsed_profile.Processes) != 1){
+		t.Errorf("Expected process count of 1")
+  }
+
+  if(len(parsed_profile.Processes[0].Threads) != 1){
+		t.Errorf("Expected thread count of 1")
+  }
+
+  frames := parsed_profile.Processes[0].Threads[0].Frames
+  if(len(frames) != 2){
+		t.Errorf("Expected thread count of %d, got, %d", 3, len(frames))
+  }
+
+  found_count := 0
+  for _, frame := range frames{
+    if frame.SymbolName == "Foo"{
+      found_count+=1
+
+      if(frame.Depth != 0){
+        t.Errorf("Wrong depth for %s. Got %d, expected %d", "Foo", frame.Depth, 0)
+      }
+
+      if(len(frame.Children) != 0){
+        t.Errorf("Foo, should not have children frames, found %d", len(frame.Children))
+      }
+    }
+
+    if frame.SymbolName == "Bar"{
+      found_count+=1
+
+      if(frame.Depth != 0){
+        t.Errorf("Wrong depth for %s. Got %d, expected %d", "Bar", frame.Depth, 0)
+      }
+
+      if(len(frame.Children) != 1){
+        t.Errorf("Bar, should have 1 child frame, found %d", len(frame.Children))
+      }
+
+      child := frame.Children[0]
+      symbol_name := child.SymbolName
+
+      if(symbol_name != "Baz"){
+        t.Errorf("Wrong symbol name for child of Bar. Got %s, expected %s", symbol_name, "Baz")
+      }
+
+      if(child.Depth != 1){
+        t.Errorf("Wrong depth for %s. Got %d, expected %d", symbol_name, frame.Depth, 0)
+      }
+
+      if(len(child.Children) != 0){
+        t.Errorf("%s, should have 0 child frame, found %d", symbol_name, len(frame.Children))
+      }
+
+    }
+  }
+
+  if(found_count != 2){
+    t.Errorf("Some of the expected frames were not found")
+  }
+}

--- a/internal/parsers/collapsed/collapsed_parser_test.go
+++ b/internal/parsers/collapsed/collapsed_parser_test.go
@@ -36,57 +36,67 @@ func TestLineParsing(t *testing.T) {
 		t.FailNow()
 	}
 
-  if(len(parsed_profile.Processes) != 1){
-		t.Errorf("Expected process count of 1")
+  // Only dummy process should be present.
+  expected_process_count := 1
+  if(len(parsed_profile.Processes) != expected_process_count){
+		t.Errorf("Expected process count of %d", expected_process_count)
   }
 
-  if(len(parsed_profile.Processes[0].Threads) != 1){
-		t.Errorf("Expected thread count of 1")
+  // Only dummy thread should be present.
+  expected_thread_count := 1
+  if(len(parsed_profile.Processes[0].Threads) != expected_thread_count){
+		t.Errorf("Expected thread count of %d", expected_thread_count)
   }
 
   frames := parsed_profile.Processes[0].Threads[0].Frames
-  if(len(frames) != 2){
-		t.Errorf("Expected thread count of %d, got, %d", 3, len(frames))
+  expected_frame_count := 2
+  if(len(frames) != expected_frame_count){
+		t.Errorf("Expected frame count of %d, got, %d", expected_frame_count, len(frames))
   }
 
+  // Keep track of how many of the expected frames we find.
   found_count := 0
+
   for _, frame := range frames{
+
     if frame.SymbolName == "Foo"{
       found_count+=1
+      symbol_name := "Foo"
 
       if(frame.Depth != 0){
-        t.Errorf("Wrong depth for %s. Got %d, expected %d", "Foo", frame.Depth, 0)
+        t.Errorf("Wrong depth for %s. Got %d, expected %d", symbol_name, frame.Depth, 0)
       }
 
       if(len(frame.Children) != 0){
-        t.Errorf("Foo, should not have children frames, found %d", len(frame.Children))
+        t.Errorf("%s, should not have children frames, found %d", symbol_name, len(frame.Children))
       }
     }
 
     if frame.SymbolName == "Bar"{
       found_count+=1
+      symbol_name := "Bar"
 
       if(frame.Depth != 0){
-        t.Errorf("Wrong depth for %s. Got %d, expected %d", "Bar", frame.Depth, 0)
-      }
-
-      if(len(frame.Children) != 1){
-        t.Errorf("Bar, should have 1 child frame, found %d", len(frame.Children))
-      }
-
-      child := frame.Children[0]
-      symbol_name := child.SymbolName
-
-      if(symbol_name != "Baz"){
-        t.Errorf("Wrong symbol name for child of Bar. Got %s, expected %s", symbol_name, "Baz")
-      }
-
-      if(child.Depth != 1){
         t.Errorf("Wrong depth for %s. Got %d, expected %d", symbol_name, frame.Depth, 0)
       }
 
+      if(len(frame.Children) != 1){
+        t.Errorf("%s, should have 1 child frame, found %d", symbol_name, len(frame.Children))
+      }
+
+      child := frame.Children[0]
+      child_symbol_name := child.SymbolName
+
+      if(child_symbol_name != "Baz"){
+        t.Errorf("Wrong symbol name for child of %s. Got %s, expected %s", symbol_name, child_symbol_name, "Baz")
+      }
+
+      if(child.Depth != 1){
+        t.Errorf("Wrong depth for %s. Got %d, expected %d", child_symbol_name, frame.Depth, 0)
+      }
+
       if(len(child.Children) != 0){
-        t.Errorf("%s, should have 0 child frame, found %d", symbol_name, len(frame.Children))
+        t.Errorf("%s, should have 0 child frame, found %d", child_symbol_name, len(frame.Children))
       }
 
     }

--- a/internal/parsers/collapsed/collapsed_parser_test.go
+++ b/internal/parsers/collapsed/collapsed_parser_test.go
@@ -16,42 +16,42 @@ package collapsed
 
 import (
   "strings"
-	"testing"
+  "testing"
 )
 
 func TestLineParsing(t *testing.T) {
   const collapsed = "Bar;Baz 2\n" +
   "Foo 2\n"
 
-	r := strings.NewReader(collapsed)
-	parser, err := MakeCollapsedParser(r)
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
+  r := strings.NewReader(collapsed)
+  parser, err := MakeCollapsedParser(r)
+  if err != nil {
+    t.Error(err)
+    t.FailNow()
+  }
 
-	parsed_profile, err := parser.ParseProfile()
-	if err != nil {
-		t.Error(err)
-		t.FailNow()
-	}
+  parsed_profile, err := parser.ParseProfile()
+  if err != nil {
+    t.Error(err)
+    t.FailNow()
+  }
 
   // Only dummy process should be present.
   expected_process_count := 1
   if(len(parsed_profile.Processes) != expected_process_count){
-		t.Errorf("Expected process count of %d", expected_process_count)
+    t.Errorf("Expected process count of %d", expected_process_count)
   }
 
   // Only dummy thread should be present.
   expected_thread_count := 1
   if(len(parsed_profile.Processes[0].Threads) != expected_thread_count){
-		t.Errorf("Expected thread count of %d", expected_thread_count)
+    t.Errorf("Expected thread count of %d", expected_thread_count)
   }
 
   frames := parsed_profile.Processes[0].Threads[0].Frames
   expected_frame_count := 2
   if(len(frames) != expected_frame_count){
-		t.Errorf("Expected frame count of %d, got, %d", expected_frame_count, len(frames))
+    t.Errorf("Expected frame count of %d, got, %d", expected_frame_count, len(frames))
   }
 
   // Keep track of how many of the expected frames we find.

--- a/internal/parsers/parser.go
+++ b/internal/parsers/parser.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/instrumentsToPprof/internal"
 	"github.com/google/instrumentsToPprof/internal/parsers/instruments"
 	"github.com/google/instrumentsToPprof/internal/parsers/sample"
+	"github.com/google/instrumentsToPprof/internal/parsers/collapsed"
 )
 
 type Parser interface {
@@ -32,4 +33,8 @@ func MakeSampleParser(file io.Reader) (Parser, error) {
 
 func MakeDeepCopyParser(file io.Reader) (Parser, error) {
 	return instruments.MakeDeepCopyParser(file)
+}
+
+func MakeCollapsedParser(file io.Reader) (Parser, error) {
+	return collapsed.MakeCollapsedParser(file)
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ Flags:
 	formatHelp = `The format of the input. Use,
 --format=sample for parsing sample files
 --format=instruments for instruments deep-copy. This is the default.
+--format=collapsed for collapsed stack format. See github.com/brendangregg/FlameGraph#2-fold-stacks
 
 Sample copying is a new feature and may have issues. File an issue on github in that case.
 `

--- a/main.go
+++ b/main.go
@@ -45,8 +45,8 @@ For example, 'My Process Name [pid: 123] [Annotation]' with -pidTag=123:Annotati
 )
 
 const (
-	kSample              string = "sample"
-	kInstrumentsDeepCopy string = "instruments"
+	kSample               string = "sample"
+	kInstrumentsDeepCopy  string = "instruments"
 	kInstrumentsCollapsed string = "collapsed"
 )
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ For example, 'My Process Name [pid: 123] [Annotation]' with -pidTag=123:Annotati
 const (
 	kSample              string = "sample"
 	kInstrumentsDeepCopy string = "instruments"
+	kInstrumentsCollapsed string = "collapsed"
 )
 
 type makeParserFn func(io.Reader) (parsers.Parser, error)
@@ -89,6 +90,8 @@ func main() {
 		parserFn = parsers.MakeSampleParser
 	} else if *format == kInstrumentsDeepCopy {
 		parserFn = parsers.MakeDeepCopyParser
+	} else if *format == kInstrumentsCollapsed {
+		parserFn = parsers.MakeCollapsedParser
 	} else {
 		log.Fatalf("Invalid file format specified: %s", *format)
 	}


### PR DESCRIPTION
Example of the format:

foo;bar;baz 7
foo;bar 2
test;fun 3

This is the format supported by some tools like https://github.com/brendangregg/FlameGraph and speedscope.app