### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The tool requires Go, which can be downloaded at the [Go homepage](https://golan
 
 `instrumentsToPprof` can be installed to the `GOPATH` using
 ```
-go install github.com/google/instrumentsToPprof
+go install github.com/google/instrumentsToPprof@latest
 ```
 
 or run directly in the repo using


### PR DESCRIPTION
Current Go tool requires specifying "@latest" for go install for non-modules.