### PR TITLE
Support nanoseconds

### DIFF
--- a/internal/parsers/instruments/deep_copy_parser.go
+++ b/internal/parsers/instruments/deep_copy_parser.go
@@ -200,7 +200,7 @@ func newProcessFromFrame(f *internal.Frame) (*internal.Process, error) {
 
 func parseSelfWeight(selfWeightText string) (int64, error) {
 	// String is in the format "2.00 ms" where valid units
-	// that I know about are "s", "ms", and "µs"
+	// that I know about are "s", "ms", "µs", and "ns".
 	// returns nanoseconds.
 
 	fields := strings.Split(selfWeightText, " ")
@@ -218,6 +218,8 @@ func parseSelfWeight(selfWeightText string) (int64, error) {
 		value *= 1_000_000
 	case "µs":
 		value *= 1_000
+	case "ns":
+		value *= 1
 	default:
 		return 0, fmt.Errorf("Could not interpret time unit '%s' in %s", selfWeightText, fields[1])
 	}

--- a/internal/parsers/instruments/deep_copy_parser_test.go
+++ b/internal/parsers/instruments/deep_copy_parser_test.go
@@ -38,6 +38,10 @@ func TestFrameTimeUnitParsing(t *testing.T) {
 			input: "100.00 µs",
 			expectedNs: 100_000,
 		},
+		{
+			input: "100.00 ns",
+			expectedNs: 100,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
A trace can contain units in nanoseconds. Example:

```
542 ns    0.0%  542 ns                                                                mach_msg2_trap
```

This fails with the following error:

```
2023/03/21 20:12:49 Failed to parse deep copy: Could not interpret time unit '542 ns' in ns
```

This commit fixes the above issue.