### PR TITLE
Fix Instruments deep copy parsing of self weights and thread IDs

### DIFF
--- a/internal/parsers/instruments/deep_copy_parser.go
+++ b/internal/parsers/instruments/deep_copy_parser.go
@@ -152,7 +152,7 @@ func newThreadFromFrame(f *internal.Frame) (*internal.Thread, error) {
 	// "<thread name> 0x<tid>" (newer Instruments).
 	// The first group is made un-greedy so it doesn't match the second space between
 	// the thread name and tid if there is one.
-	threadRe := regexp.MustCompile(`(.*?)(?:\s\s|\s)0x([0-9a-f]+)$`)
+	threadRe := regexp.MustCompile(`(.*?)(?:\s+|\s+\()0x([0-9a-f]+)\)?$`)
 	matches := threadRe.FindStringSubmatch(f.SymbolName)
 	if len(matches) != 3 {
 		fmt.Printf("WARNING: Error parsing thread '%s'. Skipping thread name parsing.\n", f.SymbolName)
@@ -206,7 +206,7 @@ func parseSelfWeight(selfWeightText string) (int64, error) {
 	// that I know about are "s", "ms", "µs", and "ns".
 	// returns nanoseconds.
 
-	fields := strings.Split(selfWeightText, " ")
+	fields := strings.Fields(selfWeightText)
 	if len(fields) != 2 {
 		return 0, fmt.Errorf("Self weight not parsable: was not 2 fields in \"%s\"", selfWeightText)
 	}

--- a/internal/parsers/instruments/deep_copy_parser_test.go
+++ b/internal/parsers/instruments/deep_copy_parser_test.go
@@ -17,6 +17,8 @@ package instruments
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/instrumentsToPprof/internal"
 )
 
 func TestFrameTimeUnitParsing(t *testing.T) {
@@ -41,6 +43,14 @@ func TestFrameTimeUnitParsing(t *testing.T) {
 		{
 			input: "100.00 ns",
 			expectedNs: 100,
+		},
+		{
+			input: "0 s     ",
+			expectedNs: 0,
+		},
+		{
+			input: " 1.25 ms  ",
+			expectedNs: 1_250_000,
 		},
 	}
 
@@ -139,5 +149,47 @@ func TestInvalidThreadAndProcessNames(t *testing.T) {
 	}
 	if got.Processes[0].Threads[0].Name != "Thread 1  1ee7" {
 		t.Errorf("Expected thread name %s was %s", "Thread 1  1ee7", got.Processes[0].Threads[0].Name)
+	}
+}
+
+func TestNewThreadFromFrame(t *testing.T) {
+	type testCase struct {
+		symbolName   string
+		expectedName string
+		expectedTid  uint64
+	}
+	cases := []testCase{
+		{
+			symbolName:   "Thread 1  0x1ee7",
+			expectedName: "Thread 1",
+			expectedTid:  0x1ee7,
+		},
+		{
+			symbolName:   "Thread 2 0x7ee1",
+			expectedName: "Thread 2",
+			expectedTid:  0x7ee1,
+		},
+		{
+			symbolName:   "Main Thread (0x9ec1)",
+			expectedName: "Main Thread",
+			expectedTid:  0x9ec1,
+		},
+	}
+	for _, c := range cases {
+		f := &internal.Frame{
+			Depth:      1,
+			SymbolName: c.symbolName,
+		}
+		got, err := newThreadFromFrame(f)
+		if err != nil {
+			t.Errorf("Unexpected error parsing %q: %v", c.symbolName, err)
+			continue
+		}
+		if got.Name != c.expectedName {
+			t.Errorf("For %q, expected name %q, got %q", c.symbolName, c.expectedName, got.Name)
+		}
+		if got.Tid != c.expectedTid {
+			t.Errorf("For %q, expected tid %d (0x%x), got %d (0x%x)", c.symbolName, c.expectedTid, c.expectedTid, got.Tid, got.Tid)
+		}
 	}
 }


### PR DESCRIPTION
Tested with Xcode 27 Beta 4.
- Use strings.Fields instead of strings.Split when parsing self weight to handle arbitrary whitespace padding.
- Update threadRe to support thread ID formats wrapped in parentheses (e.g. 'Main Thread (0x9ec1)').
- Add unit tests for both fixes.